### PR TITLE
Add CI \o/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,129 @@
-.secrets
-docker-compose.override.yml
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,8 @@
+language: python
+install:
+  - pip install tox 
+script:
+  - tox
+env:
+  - TOXENV=pep8
+  - TOXENV=py37

--- a/hbcbot/tests/test_commands.py
+++ b/hbcbot/tests/test_commands.py
@@ -1,0 +1,10 @@
+import unittest
+
+from hbcbot import commands
+
+
+class TestAbv(unittest.TestCase):
+    def test_pastryboi(self):
+        abv = commands._abv(1.135, 1.045)
+        abv = round(abv, 1)
+        self.assertEqual(abv, 14.1)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,21 @@
+[metadata]
+name = howdy
+author = HomebrewChat
+url = https://homebrewing.slack.com
+description = Slackbot for Homebrew Chat Slack workspace
+long-description = file: README.md
+license = None
+classifiers =
+    Programming Language :: Python
+    Programming Language :: Python :: 3.7
+version = attr: setuptools_scm.get_version
+
+[options]
+python_requires = >=3.7
+zip_safe = False
+
+setup_requires =
+    setuptools_scm
+
+packages =
+    hbcbot

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+from setuptools import setup
+
+with open('requirements.txt') as f:
+    install_requires = f.read()
+
+setup(install_requires=install_requires)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+flake8
+nose

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py37,pep8
+
+[testenv]
+usedevelop = True
+deps = -rtest-requirements.txt
+commands = nosetests
+
+[testenv:pep8]
+basepython = python3
+commands = flake8 hbcbot/


### PR DESCRIPTION
This makes the app somewhat installable, adds a skeleton for unit tests,
and adds tox targets for python 3.7 (our deployment target) and linting.

It also adds a .travis.yaml file so we can run these on travis-ci.

Last, it adds a more comprehensive .gitignore file for python apps.