### PR TITLE
Use search rather than findall or match

### DIFF
--- a/hbcbot/app.py
+++ b/hbcbot/app.py
@@ -43,8 +43,7 @@ command_map = {
     'help': print_help,
 }
 
-sixtynine_pattern = re.compile('\b69+?\b')
-
+sixtynine_pattern = re.compile(r'\b69+?\b')
 
 # handler for all messages
 @slack_events_adapter.on("message")
@@ -70,7 +69,7 @@ def handle_message(event_data):
         response = cmd(args)
         slack_client.chat_postMessage(channel=channel, text=response)
 
-    if sixtynine_pattern.findall(msg_text):
+    if sixtynine_pattern.match(msg_text):
         slack_client.reactions_add(
             channel=channel,
             name="nice",

--- a/hbcbot/app.py
+++ b/hbcbot/app.py
@@ -69,7 +69,7 @@ def handle_message(event_data):
         response = cmd(args)
         slack_client.chat_postMessage(channel=channel, text=response)
 
-    if sixtynine_pattern.match(msg_text):
+    if sixtynine_pattern.search(msg_text):
         slack_client.reactions_add(
             channel=channel,
             name="nice",


### PR DESCRIPTION
```
>>> import re
>>> string1 = "69"
>>> string2 = "This is a long text string with 69+ certifications"
>>> string3 = "https://www.google.com/hrfd_6936948.jpg"
>>> string4 = "We bonked 69 times"
>>> string5 = "We bonked 690 times"
>>> niceness = re.compile(r'\b69+?\b')
>>> if niceness.search(string1):
...   print('yes!')
...
yes!
>>> if niceness.search(string2):
...   print('yes!')
...
yes!
>>> if niceness.search(string3):
...   print('yes!')
...
>>> if niceness.search(string4):
...   print('yes!')
...
yes!
>>> if niceness.search(string5):
...   print('yes!')
...
>>>
```