### PR TITLE
Add untappd feature, python-black formatting

### DIFF
--- a/hbcbot/app.py
+++ b/hbcbot/app.py
@@ -11,16 +11,16 @@ from hbcbot import commands
 app = Flask(__name__)
 
 
-@app.route('/healthcheck')
+@app.route("/healthcheck")
 def healthcheck():
-    return 'ok'
+    return "ok"
 
 
 # event handler / server
 slack_signing_secret = os.environ["SLACK_SIGNING_SECRET"]
-slack_events_adapter = SlackEventAdapter(slack_signing_secret,
-                                         endpoint="/slack/events",
-                                         server=app)
+slack_events_adapter = SlackEventAdapter(
+    slack_signing_secret, endpoint="/slack/events", server=app
+)
 
 # web API for sending messages
 slack_bot_token = os.environ["SLACK_BOT_TOKEN"]
@@ -33,14 +33,15 @@ else:
 
 
 def print_help(args):
-    return('commands: .abv .brix .hydrometer')
+    return "commands: .abv .brix .hydrometer"
 
 
 command_map = {
-    'abv': commands.calc_abv,
-    'brix': commands.brix_sg,
-    'hydrometer': commands.hydro_adj,
-    'help': print_help,
+    "abv": commands.calc_abv,
+    "brix": commands.brix_sg,
+    "hydrometer": commands.hydro_adj,
+    "help": print_help,
+    "untappd": commands.untappd,
 }
 
 
@@ -49,22 +50,22 @@ command_map = {
 def handle_message(event_data):
     message = event_data["event"]
     if debug:
-        print('event hit: %s' % event_data)
-    if message.get('subtype') is not None:
+        print("event hit: %s" % event_data)
+    if message.get("subtype") is not None:
         # nfi what this means, but it's in the example. probably threads
         return
-    msg_text = message.get('text')
+    msg_text = message.get("text")
     channel = message["channel"]
     if not msg_text:
         # wtf?
         return
 
-    if msg_text.startswith('.'):
+    if msg_text.startswith("."):
         # we have a bot command
-        cmd, *args = msg_text.lstrip('.').split()
+        cmd, *args = msg_text.lstrip(".").split()
         cmd = command_map.get(cmd.lower())
         if debug:
-            print('command hit: %s', cmd)
+            print("command hit: %s", cmd)
         if not cmd:
             return
         response = cmd(args)
@@ -72,12 +73,10 @@ def handle_message(event_data):
 
     if re.search(r"\b69\b", msg_text):
         if debug:
-            print('69 hit: %s', msg_text)
+            print("69 hit: %s", msg_text)
         slack_client.reactions_add(
-            channel=channel,
-            name="nice",
-            timestamp=message["ts"]
-            )
+            channel=channel, name="nice", timestamp=message["ts"]
+        )
 
 
 @slack_events_adapter.on("member_joined_channel")
@@ -87,13 +86,12 @@ def handle_join(event_data):
 
     if channel == "C0FKR5YDT":  # this is the ID for #general
         # if channel == "C8TTK8Y58":  # this is the ID for #bot_stuff
-        response = """HBC welcome <@%s>
-https://i.imgur.com/mHznIY8.png""" % message["user"]
-        slack_client.chat_postMessage(
-            channel=channel,
-            text=response,
-            unfurl_links=True
-            )
+        response = (
+            """HBC welcome <@%s>
+https://i.imgur.com/mHznIY8.png"""
+            % message["user"]
+        )
+        slack_client.chat_postMessage(channel=channel, text=response, unfurl_links=True)
 
 
 # Error events

--- a/hbcbot/commands.py
+++ b/hbcbot/commands.py
@@ -1,3 +1,7 @@
+import os
+import requests
+
+
 def _abv(og, fg):
     return (76.08 * (og - fg) / (1.775 - og)) * (fg / 0.794)
 
@@ -7,24 +11,32 @@ def _brix_to_og(brix):
 
 
 def _hydro_temp_adj(mg, mtemp, ctemp):
-    ag = mg * ((1.00130346 - 0.000134722124 * mtemp +
-                0.00000204052596 * mtemp**2 -
-                0.00000000232820948 * mtemp**3) /
-               (1.00130346 - 0.000134722124 * ctemp +
-                0.00000204052596 * ctemp**2 -
-                0.00000000232820948 * ctemp**3))
+    ag = mg * (
+        (
+            1.00130346
+            - 0.000134722124 * mtemp
+            + 0.00000204052596 * mtemp**2
+            - 0.00000000232820948 * mtemp**3
+        )
+        / (
+            1.00130346
+            - 0.000134722124 * ctemp
+            + 0.00000204052596 * ctemp**2
+            - 0.00000000232820948 * ctemp**3
+        )
+    )
     return ag
 
 
 def calc_abv(args):
-    usage = 'Usage: .abv <OG> <FG>'
+    usage = "Usage: .abv <OG> <FG>"
     if len(args) != 2:
         return usage
 
     try:
         og = float(args[0])
         fg = float(args[1])
-        return 'ABV is %.1f' % _abv(og, fg)
+        return "ABV is %.1f" % _abv(og, fg)
 
     except Exception:
         # not passed numbers
@@ -32,14 +44,14 @@ def calc_abv(args):
 
 
 def brix_sg(args):
-    usage = 'Usage: .brix <Original BRIX> (<Final BRIX>)'
+    usage = "Usage: .brix <Original BRIX> (<Final BRIX>)"
     if len(args) < 1 or len(args) > 2:
         return usage
 
     if len(args) == 1:
         try:
             brix = float(args[0])
-            return 'OG is %.3f' % _brix_to_og(brix)
+            return "OG is %.3f" % _brix_to_og(brix)
         except Exception:
             # not passed numbers
             return usage
@@ -49,14 +61,22 @@ def brix_sg(args):
             obrix = float(args[0])
             fbrix = float(args[1])
             sg = _brix_to_og(obrix)
-            fg = (1 -
-                  (0.004493 * obrix) + (0.011774 * fbrix) +
-                  (0.00027581 * obrix ** 2) - (0.0012717 * fbrix ** 2) -
-                  (0.00000728 * obrix ** 3) + (0.000063293 * fbrix ** 3))
+            fg = (
+                1
+                - (0.004493 * obrix)
+                + (0.011774 * fbrix)
+                + (0.00027581 * obrix**2)
+                - (0.0012717 * fbrix**2)
+                - (0.00000728 * obrix**3)
+                + (0.000063293 * fbrix**3)
+            )
             abv = _abv(sg, fg)
 
-            message = ('OG: %(og).3f; FG: %(fg).3f, ABV: %(abv).1f' %
-                       {'og': sg, 'fg': fg, 'abv': abv})
+            message = "OG: %(og).3f; FG: %(fg).3f, ABV: %(abv).1f" % {
+                "og": sg,
+                "fg": fg,
+                "abv": abv,
+            }
             return message
 
         except Exception:
@@ -65,8 +85,7 @@ def brix_sg(args):
 
 
 def hydro_adj(args):
-    usage = ('Usage: .hydrometer <Measured Gravity> <Measured Temp>'
-             '<Calibrated Temp>')
+    usage = "Usage: .hydrometer <Measured Gravity> <Measured Temp>" "<Calibrated Temp>"
     if len(args) != 3:
         return usage
 
@@ -74,8 +93,29 @@ def hydro_adj(args):
         mg = float(args[0])
         mtemp = float(args[1])
         ctemp = float(args[2])
-        return 'Adjusted Gravity is %.3f' % _hydro_temp_adj(mg, mtemp, ctemp)
+        return "Adjusted Gravity is %.3f" % _hydro_temp_adj(mg, mtemp, ctemp)
 
     except Exception:
         # not passed numbers
+        return usage
+
+
+def untappd(args):
+    usage = "Usage: .untappd <beer name>"
+
+    untappd_client_id = os.environ["UNTAPPD_CLIENT_ID"]
+    untappd_client_secret = os.environ["UNTAPPD_CLIENT_SECRET"]
+
+    api_url = f"https://api.untappd.com/v4/search/beer?q={args}&client_id={untappd_client_id}&client_secret={untappd_client_secret}"
+
+    response = requests.get(api_url)
+
+    if response.status_code == 200:
+        data = response.json()
+        try:
+            bid = data["response"]["beers"]["items"][0]["beer"]["bid"]
+        except:
+            return "Type in beer name accurately"
+        return f"https://untappd.com/beer/{bid}"
+    else:
         return usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+requests
 slackeventsapi
 slack_sdk


### PR DESCRIPTION
Slack untappd feature was killed when Heroku deprecated the free tier. we should add something basic to the bot.

I also used https://github.com/psf/black.